### PR TITLE
Django 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: python
-matrix:
-    exclude:
-        - python: "3.3"
-          env: DJANGO_VERSION=1.4.10
-python:
-  - "2.7"
-  - "3.3"
-env:
-    - DJANGO_VERSION=1.4.10
-    - DJANGO_VERSION=1.5.5
-    - DJANGO_VERSION=1.6.2
-install:
-    - pip install -q nose django-nose Django==$DJANGO_VERSION coverage
-    - pip install .
+python: 3.5
+sudo: false
 
-script: python runtests.py
+env:
+  - TOX_ENV=py27-django18
+  - TOX_ENV=py34-django18
+  - TOX_ENV=py35-django18
+  - TOX_ENV=py27-django19
+  - TOX_ENV=py34-django19
+  - TOX_ENV=py35-django19
+
+install:
+    - pip install tox
+
+script:
+  - tox -e $TOX_ENV

--- a/arrow_field/form_fields.py
+++ b/arrow_field/form_fields.py
@@ -1,9 +1,8 @@
 from __future__ import unicode_literals
+
 import arrow
-from django.conf import settings
 from django.forms import DateTimeField
 from django.utils import timezone
-from django.forms.util import from_current_timezone, to_current_timezone
 
 
 class ArrowField(DateTimeField):
@@ -21,7 +20,7 @@ class ArrowField(DateTimeField):
 
     def prepare_value(self, value):
         if isinstance(value, arrow.Arrow):
-                return value.naive
+            return value.naive
         return super(ArrowField, self).to_python(value)
 
     def to_python(self, value):

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -7,9 +7,11 @@ from arrow_field.form_fields import ISO8601ArrowField
 class PersonForm(ModelForm):
     class Meta:
         model = Person
+        fields = ['first_name', 'birthday']
 
 
 class ISO8601PersonForm(ModelForm):
     birthday = ISO8601ArrowField()
     class Meta:
         model = Person
+        fields = ['first_name', 'birthday']

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,60 @@
+[tox]
+envlist=
+    py27-django18,
+    py34-django18,
+    py35-django18,
+    py27-django19,
+    py34-django19,
+    py35-django19,
+
+[testenv]
+commands=
+    python runtests.py
+
+[testenv:py27-django18]
+basepython=python2.7
+deps=
+    coverage
+    django-nose
+    nose
+    Django==1.8
+
+[testenv:py34-django18]
+basepython=python3.4
+deps=
+    coverage
+    django-nose
+    nose
+    Django==1.8
+
+[testenv:py35-django18]
+basepython=python3.5
+deps=
+    coverage
+    django-nose
+    nose
+    Django==1.8
+
+[testenv:py27-django19]
+basepython=python2.7
+deps=
+    coverage
+    django-nose
+    nose
+    Django==1.9
+
+[testenv:py34-django19]
+basepython=python3.4
+deps=
+    coverage
+    django-nose
+    nose
+    Django==1.9
+
+[testenv:py35-django19]
+basepython=python3.5
+deps=
+    coverage
+    django-nose
+    nose
+    Django==1.9


### PR DESCRIPTION
This PR adds support for Django 1.9 and updates travis tests to test on python 2.7, 3.4, 3.5 with the currently officially supported django 1.8 and 1.9 versions.
